### PR TITLE
xcode 10 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.4
+osx_image: xcode10
 language: swift
 
 branches:

--- a/OCast.xcodeproj/project.pbxproj
+++ b/OCast.xcodeproj/project.pbxproj
@@ -54,10 +54,9 @@
 		97DC97BC20EA302500DBB1B0 /* Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DC978B20EA302400DBB1B0 /* Compression.swift */; };
 		97DC97BD20EA302500DBB1B0 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DC978C20EA302400DBB1B0 /* SSLSecurity.swift */; };
 		97DC97BE20EA302500DBB1B0 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DC978D20EA302400DBB1B0 /* WebSocket.swift */; };
-		97DC97BF20EA302500DBB1B0 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 97DC978E20EA302400DBB1B0 /* Info.plist */; };
 		97DC97C220EA313800DBB1B0 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 97DC97C120EA313800DBB1B0 /* libz.tbd */; };
-		B946C9FEB8CBEC1C58CB6688 /* Pods_OCastTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7630D70A16E0DF7E12B9701A /* Pods_OCastTests.framework */; };
-		E19252B0E29FC58889D14DF2 /* Pods_OCast.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97992A89EAE79D85ACFECE6F /* Pods_OCast.framework */; };
+		CE64FD5651D1713F9E59186E /* Pods_OCastTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F9D010C25D3F8143329984C /* Pods_OCastTests.framework */; };
+		E5C0422559CA476DE81FF503 /* Pods_OCast.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94033FF71A7BA57C853AF46A /* Pods_OCast.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,11 +70,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		075C825A936085344F863840 /* Pods-OCast.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCast.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCast/Pods-OCast.release.xcconfig"; sourceTree = "<group>"; };
-		21BBC284E62D7C66DAFE7013 /* Pods-OCastTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests.debug.xcconfig"; sourceTree = "<group>"; };
-		7630D70A16E0DF7E12B9701A /* Pods_OCastTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7BC0E484F5024A7A1BA54D55 /* Pods-OCast.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCast.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCast/Pods-OCast.debug.xcconfig"; sourceTree = "<group>"; };
-		9490143AE82EE796955E6571 /* Pods-OCastTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests.release.xcconfig"; sourceTree = "<group>"; };
+		2A5A6E6710865967995199A4 /* Pods-OCast.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCast.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCast/Pods-OCast.debug.xcconfig"; sourceTree = "<group>"; };
+		55997461E6B225FD51BD3D75 /* Pods-OCastTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6F9D010C25D3F8143329984C /* Pods_OCastTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		72FBC7B997F2E02A32F442DE /* Pods-OCast.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCast.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCast/Pods-OCast.release.xcconfig"; sourceTree = "<group>"; };
+		94033FF71A7BA57C853AF46A /* Pods_OCast.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCast.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9726F0B920EFA6E400BAE3BC /* WifiSecurity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WifiSecurity.h; sourceTree = "<group>"; };
 		9751ADC320F655C200815600 /* ReferenceDriverErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceDriverErrorCode.swift; sourceTree = "<group>"; };
 		9751ADC620FDD40200815600 /* OCastDiscoveryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCastDiscoveryTests.swift; sourceTree = "<group>"; };
@@ -83,7 +82,6 @@
 		9751ADC820FDD40200815600 /* OCastTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OCastTestCase.swift; sourceTree = "<group>"; };
 		9751ADCD20FDEB3100815600 /* OCastApplicationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCastApplicationControllerTests.swift; sourceTree = "<group>"; };
 		9751ADCF20FDED2600815600 /* DeviceDiscoveryDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceDiscoveryDelegate.swift; sourceTree = "<group>"; };
-		97992A89EAE79D85ACFECE6F /* Pods_OCast.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCast.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97AF813820EA0EAD00C502D5 /* OCast.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCast.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		97AF813B20EA0EAD00C502D5 /* OCast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCast.h; sourceTree = "<group>"; };
 		97AF813C20EA0EAD00C502D5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -116,6 +114,7 @@
 		97DC978D20EA302400DBB1B0 /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
 		97DC978E20EA302400DBB1B0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		97DC97C120EA313800DBB1B0 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		B8FF8FE0EA17292D67A6ED01 /* Pods-OCastTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,7 +123,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				97DC97C220EA313800DBB1B0 /* libz.tbd in Frameworks */,
-				E19252B0E29FC58889D14DF2 /* Pods_OCast.framework in Frameworks */,
+				E5C0422559CA476DE81FF503 /* Pods_OCast.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,7 +132,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				97AF814220EA0EAD00C502D5 /* OCast.framework in Frameworks */,
-				B946C9FEB8CBEC1C58CB6688 /* Pods_OCastTests.framework in Frameworks */,
+				CE64FD5651D1713F9E59186E /* Pods_OCastTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,8 +143,8 @@
 			isa = PBXGroup;
 			children = (
 				97DC97C120EA313800DBB1B0 /* libz.tbd */,
-				97992A89EAE79D85ACFECE6F /* Pods_OCast.framework */,
-				7630D70A16E0DF7E12B9701A /* Pods_OCastTests.framework */,
+				94033FF71A7BA57C853AF46A /* Pods_OCast.framework */,
+				6F9D010C25D3F8143329984C /* Pods_OCastTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -156,8 +155,8 @@
 				97AF813A20EA0EAD00C502D5 /* OCast */,
 				97AF814520EA0EAD00C502D5 /* OCastTests */,
 				97AF813920EA0EAD00C502D5 /* Products */,
-				9CC673FA82947CFF7A0F178B /* Pods */,
 				723607DAA28AC9307C112C12 /* Frameworks */,
+				C5C01EFD019F57267C63563B /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -325,13 +324,13 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		9CC673FA82947CFF7A0F178B /* Pods */ = {
+		C5C01EFD019F57267C63563B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				7BC0E484F5024A7A1BA54D55 /* Pods-OCast.debug.xcconfig */,
-				075C825A936085344F863840 /* Pods-OCast.release.xcconfig */,
-				21BBC284E62D7C66DAFE7013 /* Pods-OCastTests.debug.xcconfig */,
-				9490143AE82EE796955E6571 /* Pods-OCastTests.release.xcconfig */,
+				2A5A6E6710865967995199A4 /* Pods-OCast.debug.xcconfig */,
+				72FBC7B997F2E02A32F442DE /* Pods-OCast.release.xcconfig */,
+				55997461E6B225FD51BD3D75 /* Pods-OCastTests.debug.xcconfig */,
+				B8FF8FE0EA17292D67A6ED01 /* Pods-OCastTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -357,7 +356,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97AF814C20EA0EAD00C502D5 /* Build configuration list for PBXNativeTarget "OCast" */;
 			buildPhases = (
-				014024BD9B1264FE97462386 /* [CP] Check Pods Manifest.lock */,
+				974F450D76AAE48BA45CB94E /* [CP] Check Pods Manifest.lock */,
 				97AF813320EA0EAD00C502D5 /* Sources */,
 				97AF813420EA0EAD00C502D5 /* Frameworks */,
 				97AF813520EA0EAD00C502D5 /* Headers */,
@@ -376,11 +375,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97AF814F20EA0EAD00C502D5 /* Build configuration list for PBXNativeTarget "OCastTests" */;
 			buildPhases = (
-				C8EDBDD58BDD95F36EB3AF81 /* [CP] Check Pods Manifest.lock */,
+				563FCD5953A0ACB6605C9DFF /* [CP] Check Pods Manifest.lock */,
 				97AF813D20EA0EAD00C502D5 /* Sources */,
 				97AF813E20EA0EAD00C502D5 /* Frameworks */,
 				97AF813F20EA0EAD00C502D5 /* Resources */,
-				A9CE69A586A85CB3ADCD82EF /* [CP] Embed Pods Frameworks */,
+				629262CAAC55C6A72D607A8E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -439,7 +438,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				97DC97BF20EA302500DBB1B0 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -453,7 +451,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		014024BD9B1264FE97462386 /* [CP] Check Pods Manifest.lock */ = {
+		563FCD5953A0ACB6605C9DFF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-OCastTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		629262CAAC55C6A72D607A8E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Swifter/Swifter.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Swifter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaAsyncSocket.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		974F450D76AAE48BA45CB94E /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -482,45 +518,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "Scripts/build-fat-framework.sh";
-		};
-		A9CE69A586A85CB3ADCD82EF /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Swifter/Swifter.framework",
-				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Swifter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaAsyncSocket.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OCastTests/Pods-OCastTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C8EDBDD58BDD95F36EB3AF81 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-OCastTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "Scripts/build-fat-framework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -637,6 +635,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_INCLUDE_PATHS = $SRCROOT/OCast/Starscream/zlib;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -694,6 +693,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_INCLUDE_PATHS = $SRCROOT/OCast/Starscream/zlib;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -702,7 +702,7 @@
 		};
 		97AF814D20EA0EAD00C502D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7BC0E484F5024A7A1BA54D55 /* Pods-OCast.debug.xcconfig */;
+			baseConfigurationReference = 2A5A6E6710865967995199A4 /* Pods-OCast.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -720,14 +720,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.orange.OCast;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		97AF814E20EA0EAD00C502D5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 075C825A936085344F863840 /* Pods-OCast.release.xcconfig */;
+			baseConfigurationReference = 72FBC7B997F2E02A32F442DE /* Pods-OCast.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -745,14 +744,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.orange.OCast;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
 		97AF815020EA0EAD00C502D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 21BBC284E62D7C66DAFE7013 /* Pods-OCastTests.debug.xcconfig */;
+			baseConfigurationReference = 55997461E6B225FD51BD3D75 /* Pods-OCastTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -765,14 +763,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.orange..OCastTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		97AF815120EA0EAD00C502D5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9490143AE82EE796955E6571 /* Pods-OCastTests.release.xcconfig */;
+			baseConfigurationReference = B8FF8FE0EA17292D67A6ED01 /* Pods-OCastTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -784,7 +781,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.orange..OCastTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/OCast.xcodeproj/xcuserdata/francoissuc.xcuserdatad/xcschemes/FatFramework.xcscheme
+++ b/OCast.xcodeproj/xcuserdata/francoissuc.xcuserdatad/xcschemes/FatFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/OCast.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/OCast.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
 </plist>

--- a/OCast/ReferenceDriver/Driver/ReferenceDriver.swift
+++ b/OCast/ReferenceDriver/Driver/ReferenceDriver.swift
@@ -30,10 +30,10 @@ import Foundation
     // MARK: - Public properties
     
     /// Target that matches with this driver.
-    open static let searchTarget = "urn:cast-ocast-org:service:cast:1"
+    public static let searchTarget = "urn:cast-ocast-org:service:cast:1"
     
     /// Manufacturer name that matches with this driver.
-    open static let manufacturer = "Orange SA"
+    public static let manufacturer = "Orange SA"
     
     /// Reference driver error domain
     public static let referenceDriverErrorDomain = "ReferenceDriverErrorDomain"

--- a/OCastDemo.xcodeproj/project.pbxproj
+++ b/OCastDemo.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		8E39210D51F78A49AD86279F /* Pods_OCastDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 071A50D93264B2ACA1650445 /* Pods_OCastDemoSwift.framework */; };
+		1E149D0F32D7EB576FF66C78 /* Pods_OCastDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BAF339028FFB9FF6D7F1A1B /* Pods_OCastDemoSwift.framework */; };
+		73BF1E0E03375CD66CA4A455 /* Pods_OCastDemoObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1987F335FA56660BC2E6F66B /* Pods_OCastDemoObjC.framework */; };
 		97386DF220EB72AB0070AD91 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 97386DF120EB72AB0070AD91 /* AppDelegate.m */; };
 		97386DF520EB72AB0070AD91 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 97386DF420EB72AB0070AD91 /* ViewController.m */; };
 		97386DFA20EB72AB0070AD91 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97386DF920EB72AB0070AD91 /* Assets.xcassets */; };
@@ -21,13 +22,15 @@
 		97AF816920EA112D00C502D5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97AF816720EA112D00C502D5 /* LaunchScreen.storyboard */; };
 		97F35C0020EBCDA400798238 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 97F35BFF20EBCDA400798238 /* Constants.m */; };
 		97F35C0120EBCDA400798238 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 97F35BFF20EBCDA400798238 /* Constants.m */; };
-		A4EEB08EB7DD1A8E5C2D3F83 /* Pods_OCastDemoObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B41F474D9947297E4FB51A6A /* Pods_OCastDemoObjC.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		071A50D93264B2ACA1650445 /* Pods_OCastDemoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastDemoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		53140240DD731ADCA3B2300A /* Pods-OCastDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoSwift/Pods-OCastDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
-		5D9138B3A69D4544F3B515A8 /* Pods-OCastDemoObjC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoObjC.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC.release.xcconfig"; sourceTree = "<group>"; };
+		1987F335FA56660BC2E6F66B /* Pods_OCastDemoObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastDemoObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1B067DFFD59A590CD6BEEED3 /* Pods-OCastDemoObjC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoObjC.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC.release.xcconfig"; sourceTree = "<group>"; };
+		3EB5B4A3FE10D04BFF17C37A /* Pods-OCastDemoObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC.debug.xcconfig"; sourceTree = "<group>"; };
+		4BAF339028FFB9FF6D7F1A1B /* Pods_OCastDemoSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastDemoSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D74A27745A131DD0D01E759 /* Pods-OCastDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoSwift/Pods-OCastDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
+		8FC1B6704B09EC2C3D4A0D9C /* Pods-OCastDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoSwift.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoSwift/Pods-OCastDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		97386DEE20EB72AB0070AD91 /* OCastDemoObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OCastDemoObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97386DF020EB72AB0070AD91 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		97386DF120EB72AB0070AD91 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -48,12 +51,6 @@
 		97F35BFB20EBCCAF00798238 /* OCastDemoSwift-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OCastDemoSwift-Bridging-Header.h"; sourceTree = "<group>"; };
 		97F35BFC20EBCCAF00798238 /* Constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		97F35BFF20EBCDA400798238 /* Constants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Constants.m; sourceTree = "<group>"; };
-		A9A6774681D5FF358AAFD43D /* Pods-OCastDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemo/Pods-OCastDemo.release.xcconfig"; sourceTree = "<group>"; };
-		B41F474D9947297E4FB51A6A /* Pods_OCastDemoObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastDemoObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BF7A85CE9041CA238B59318F /* Pods-OCastDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemo/Pods-OCastDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		C3765663959701783532DD5A /* Pods_OCastDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OCastDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C4F225F1987D729C77257EA9 /* Pods-OCastDemoSwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoSwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoSwift/Pods-OCastDemoSwift.release.xcconfig"; sourceTree = "<group>"; };
-		D170636DF3B6F420A2FB5A7F /* Pods-OCastDemoObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OCastDemoObjC.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,7 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A4EEB08EB7DD1A8E5C2D3F83 /* Pods_OCastDemoObjC.framework in Frameworks */,
+				73BF1E0E03375CD66CA4A455 /* Pods_OCastDemoObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -69,19 +66,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E39210D51F78A49AD86279F /* Pods_OCastDemoSwift.framework in Frameworks */,
+				1E149D0F32D7EB576FF66C78 /* Pods_OCastDemoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0875D887D3F4523A9A1D0FAB /* Frameworks */ = {
+		0EDBDD4F54DA6D0D92A5B9F0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				C3765663959701783532DD5A /* Pods_OCastDemo.framework */,
-				071A50D93264B2ACA1650445 /* Pods_OCastDemoSwift.framework */,
-				B41F474D9947297E4FB51A6A /* Pods_OCastDemoObjC.framework */,
+				1987F335FA56660BC2E6F66B /* Pods_OCastDemoObjC.framework */,
+				4BAF339028FFB9FF6D7F1A1B /* Pods_OCastDemoSwift.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -109,8 +105,8 @@
 				97AF815D20EA112C00C502D5 /* OCastDemoSwift */,
 				97386DEF20EB72AB0070AD91 /* OCastDemoObjC */,
 				97AF815C20EA112C00C502D5 /* Products */,
-				C7AA3D6101AC4AD1680C13C8 /* Pods */,
-				0875D887D3F4523A9A1D0FAB /* Frameworks */,
+				FEF30D305E0663B3039083A2 /* Pods */,
+				0EDBDD4F54DA6D0D92A5B9F0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -146,15 +142,13 @@
 			path = OCastDemoCommon;
 			sourceTree = "<group>";
 		};
-		C7AA3D6101AC4AD1680C13C8 /* Pods */ = {
+		FEF30D305E0663B3039083A2 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BF7A85CE9041CA238B59318F /* Pods-OCastDemo.debug.xcconfig */,
-				A9A6774681D5FF358AAFD43D /* Pods-OCastDemo.release.xcconfig */,
-				53140240DD731ADCA3B2300A /* Pods-OCastDemoSwift.debug.xcconfig */,
-				C4F225F1987D729C77257EA9 /* Pods-OCastDemoSwift.release.xcconfig */,
-				D170636DF3B6F420A2FB5A7F /* Pods-OCastDemoObjC.debug.xcconfig */,
-				5D9138B3A69D4544F3B515A8 /* Pods-OCastDemoObjC.release.xcconfig */,
+				3EB5B4A3FE10D04BFF17C37A /* Pods-OCastDemoObjC.debug.xcconfig */,
+				1B067DFFD59A590CD6BEEED3 /* Pods-OCastDemoObjC.release.xcconfig */,
+				8FC1B6704B09EC2C3D4A0D9C /* Pods-OCastDemoSwift.debug.xcconfig */,
+				4D74A27745A131DD0D01E759 /* Pods-OCastDemoSwift.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -166,11 +160,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97386E0320EB72AB0070AD91 /* Build configuration list for PBXNativeTarget "OCastDemoObjC" */;
 			buildPhases = (
-				BB08A3F9B222D0B4D4E6EC80 /* [CP] Check Pods Manifest.lock */,
+				6539A2923D3689F906C1C83B /* [CP] Check Pods Manifest.lock */,
 				97386DEA20EB72AB0070AD91 /* Sources */,
 				97386DEB20EB72AB0070AD91 /* Frameworks */,
 				97386DEC20EB72AB0070AD91 /* Resources */,
-				1E163F2D51AA58AE73CCB7E9 /* [CP] Embed Pods Frameworks */,
+				E973CC310CE837C84B93F0A6 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -185,11 +179,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97AF816D20EA112D00C502D5 /* Build configuration list for PBXNativeTarget "OCastDemoSwift" */;
 			buildPhases = (
-				D68C1B1FEFF8D3B929E4D760 /* [CP] Check Pods Manifest.lock */,
+				B12316BC7AB70FB2ACFF0F0B /* [CP] Check Pods Manifest.lock */,
 				97AF815720EA112C00C502D5 /* Sources */,
 				97AF815820EA112C00C502D5 /* Frameworks */,
 				97AF815920EA112C00C502D5 /* Resources */,
-				2964CD3E083B545AEDB20AC9 /* [CP] Embed Pods Frameworks */,
+				8647B87A35E9701730B88BA5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -207,7 +201,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = Orange;
 				TargetAttributes = {
 					97386DED20EB72AB0070AD91 = {
@@ -262,27 +256,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1E163F2D51AA58AE73CCB7E9 /* [CP] Embed Pods Frameworks */ = {
+		6539A2923D3689F906C1C83B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
-				"${BUILT_PRODUCTS_DIR}/OCast/OCast.framework",
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaAsyncSocket.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCast.framework",
+				"$(DERIVED_FILE_DIR)/Pods-OCastDemoObjC-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2964CD3E083B545AEDB20AC9 /* [CP] Embed Pods Frameworks */ = {
+		8647B87A35E9701730B88BA5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -302,25 +294,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OCastDemoSwift/Pods-OCastDemoSwift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BB08A3F9B222D0B4D4E6EC80 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-OCastDemoObjC-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D68C1B1FEFF8D3B929E4D760 /* [CP] Check Pods Manifest.lock */ = {
+		B12316BC7AB70FB2ACFF0F0B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -336,6 +310,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E973CC310CE837C84B93F0A6 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CocoaAsyncSocket/CocoaAsyncSocket.framework",
+				"${BUILT_PRODUCTS_DIR}/OCast/OCast.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaAsyncSocket.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCast.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-OCastDemoObjC/Pods-OCastDemoObjC-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -402,7 +396,7 @@
 /* Begin XCBuildConfiguration section */
 		97386E0120EB72AB0070AD91 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D170636DF3B6F420A2FB5A7F /* Pods-OCastDemoObjC.debug.xcconfig */;
+			baseConfigurationReference = 3EB5B4A3FE10D04BFF17C37A /* Pods-OCastDemoObjC.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -419,7 +413,7 @@
 		};
 		97386E0220EB72AB0070AD91 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5D9138B3A69D4544F3B515A8 /* Pods-OCastDemoObjC.release.xcconfig */;
+			baseConfigurationReference = 1B067DFFD59A590CD6BEEED3 /* Pods-OCastDemoObjC.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -491,6 +485,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -544,13 +539,14 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
 		97AF816E20EA112D00C502D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 53140240DD731ADCA3B2300A /* Pods-OCastDemoSwift.debug.xcconfig */;
+			baseConfigurationReference = 8FC1B6704B09EC2C3D4A0D9C /* Pods-OCastDemoSwift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -564,14 +560,13 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "OCastDemoSwift/OCastDemoSwift-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
 		97AF816F20EA112D00C502D5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C4F225F1987D729C77257EA9 /* Pods-OCastDemoSwift.release.xcconfig */;
+			baseConfigurationReference = 4D74A27745A131DD0D01E759 /* Pods-OCastDemoSwift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -584,7 +579,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.orange.OCastDemoSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "OCastDemoSwift/OCastDemoSwift-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/OCastDemoSwift/AppDelegate.swift
+++ b/OCastDemoSwift/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         return true
     }
 

--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,7 @@ target :OCastTests do
     platform :ios, '8.0'
     project 'OCast.xcodeproj'
     #pod 'CocoaAsyncSocket', '7.6.3'
-    pod 'Swifter', :git => 'https://github.com/marcc-orange/swifter.git', :branch => 'wsConnect'
+    pod 'Swifter', :git => 'https://github.com/marcc-orange/swifter.git', :branch => 'stable'
 end
 
 target :OCastDemoSwift do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - CocoaAsyncSocket (7.6.3)
-  - OCast (1.2.1):
-    - OCast/Core (= 1.2.1)
-    - OCast/ReferenceDriver (= 1.2.1)
-  - OCast/Core (1.2.1):
+  - OCast (1.3.0):
+    - OCast/Core (= 1.3.0)
+    - OCast/ReferenceDriver (= 1.3.0)
+  - OCast/Core (1.3.0):
     - CocoaAsyncSocket (= 7.6.3)
-  - OCast/ReferenceDriver (1.2.1):
+  - OCast/ReferenceDriver (1.3.0):
     - OCast/Core
   - Swifter (1.4.1)
 
 DEPENDENCIES:
   - CocoaAsyncSocket (= 7.6.3)
   - OCast (from `./`)
-  - Swifter (from `https://github.com/marcc-orange/swifter.git`, branch `wsConnect`)
+  - Swifter (from `https://github.com/marcc-orange/swifter.git`, branch `stable`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -22,19 +22,19 @@ EXTERNAL SOURCES:
   OCast:
     :path: "./"
   Swifter:
-    :branch: wsConnect
+    :branch: stable
     :git: https://github.com/marcc-orange/swifter.git
 
 CHECKOUT OPTIONS:
   Swifter:
-    :commit: 919ba13f390b5338f074fb5aaf327f591e7f128a
+    :commit: e1210bc24071d23533033cee94f95ba630de332e
     :git: https://github.com/marcc-orange/swifter.git
 
 SPEC CHECKSUMS:
   CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
-  OCast: e53a993b7cfdfc87d831fbaf155c02878300eeaf
+  OCast: 572339d7ce5f5b940174a5dd6b0acc83aeba5a98
   Swifter: 62d14781d34600ffb6be99d350cf271be500600f
 
-PODFILE CHECKSUM: 999d7f55730a06bbeb386201b1c30da0f75dac13
+PODFILE CHECKSUM: a802031d5c938076042ae8fd28af776322dfd580
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
- Code migration to Swift 4.2
- Use legacy system build for now because with the new one, there are suspicious warnings
- Use Travis Xcode 10 image